### PR TITLE
Added support for generic type parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Java Generator
+# Java Generator Plus
 
 An Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.
 
@@ -10,3 +10,5 @@ ctrl-alt-c: Generate Constructor
 ctrl-alt-t: Generate toString Method
 ctrl-alt-b: Generate Builder Method
 ```
+
+This project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)

--- a/lib/parser.coffee
+++ b/lib/parser.coffee
@@ -2,13 +2,14 @@ Variable = require './variable'
 
 module.exports =
 class Parser
-    varRegexArray: /(public|private|protected)\s*(static)?\s*(final)?\s*(volatile|transient)?\s*([a-zA-Z0-9_$\<\>]+)\s*([a-zA-Z0-9_$]+)(\(.*\))?/g
-    varRegex: /(public|private|protected)\s*(static)?\s*(final)?\s*(volatile|transient)?\s*([a-zA-Z0-9_$\<\>]+)\s*([a-zA-Z0-9_$]+)(\(.*\))?/
+    varRegexArray: /(public|private|protected)\s*(static)?\s*(final)?\s*(volatile|transient)?\s*([a-zA-Z0-9_$]+)\s*(\<.*\>)*\s*([a-zA-Z0-9_$]+)(\(.*\))?/g
+    varRegex: /(public|private|protected)\s*(static)?\s*(final)?\s*(volatile|transient)?\s*([a-zA-Z0-9_$]+)\s*(\<.*\>)*\s*([a-zA-Z0-9_$]+)(\(.*\))?/
     methodRegex: /\(([a-zA-Z0-9_$\<\>\.\,\s]+)?\)/
     classNameRegex: /(?:class)\s+([a-zA-Z0-9_$]+)/
     classRegex: /class/
     finalRegex: /^final$/
     staticRegex: /^static$/
+    typeParameterRegex: /^\<.*\>$/
     content: ''
 
     setContent: (@content) ->
@@ -33,6 +34,7 @@ class Parser
                 if group != null
                     isStatic = false
                     isFinal = false
+                    type = group[5]
 
                     # Check if static
                     if group[2] != null && @staticRegex.test(group[2])
@@ -42,8 +44,11 @@ class Parser
                     if group[3] != null && @finalRegex.test(group[3])
                         isFinal = true
 
+                    if group[6] != null && @typeParameterRegex.test(group[6])
+                        type = type + group[6]
+
                     # Create variable and store it
-                    variable = new Variable(group[6], group[5], isStatic, isFinal)
+                    variable = new Variable(group[7], type, isStatic, isFinal)
                     variables.push (variable)
 
         return variables

--- a/package.json
+++ b/package.json
@@ -1,69 +1,66 @@
 {
-  "name": "java-generator",
-  "main": "./lib/java-generator",
-  "version": "2.3.0",
-  "private": true,
-  "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/concon121/java-generator-plus"
-  },
-  "bugs": {
-    "url": "https://github.com/concon121/java-generator-plus/issues"
-  },
-  "license": "Apache 2.0",
-  "author": {
-    "name": "Tom Delebo",
-    "url": "https://github.com/delebota"
-  },
-  "engines": {
-    "atom": ">=1.0.0 <2.0.0"
-  },
-  "dependencies": {},
-  "activationCommands": {
-    "atom-workspace": [
-      "java-generator:generate-constructor",
-      "java-generator:generate-to-string",
-      "java-generator:generate-builder",
-      "java-generator:generate-getters-setters"
-    ]
-  },
-  "keywords": [
-    "atom",
-    "java",
-    "get",
-    "getter",
-    "set",
-    "setter",
-    "constructor",
-    "toString",
-    "generate",
-    "format",
-    "auto",
-    "automatic",
-    "builder"
-  ],
-  "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
-  "readmeFilename": "README.md",
-  "homepage": "https://github.com/concon121/java-generator-plus/#readme",
-  "_id": "java-generator@2.1.0",
-  "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
-  "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
-  "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
-  "_atomModuleCache": {
-    "version": 1,
-    "dependencies": [],
-    "extensions": {
-      ".coffee": [
-        "lib\\command.coffee",
-        "lib\\java-generator.coffee",
-        "lib\\parser.coffee",
-        "lib\\variable.coffee"
-      ],
-      ".json": [
-        "package.json"
-      ]
+    "name": "java-generator",
+    "main": "./lib/java-generator",
+    "version": "2.3.0",
+    "private": true,
+    "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
+    "repository": "https://github.com/concon121/java-generator-plus",
+    "bugs": {
+        "url": "https://github.com/concon121/java-generator-plus/issues"
     },
-    "folders": []
-  }
+    "license": "Apache 2.0",
+    "author": {
+        "name": "Tom Delebo",
+        "url": "https://github.com/delebota"
+    },
+    "engines": {
+        "atom": ">=1.0.0 <2.0.0"
+    },
+    "dependencies": {},
+    "activationCommands": {
+        "atom-workspace": [
+            "java-generator:generate-constructor",
+            "java-generator:generate-to-string",
+            "java-generator:generate-builder",
+            "java-generator:generate-getters-setters"
+        ]
+    },
+    "keywords": [
+        "atom",
+        "java",
+        "get",
+        "getter",
+        "set",
+        "setter",
+        "constructor",
+        "toString",
+        "generate",
+        "format",
+        "auto",
+        "automatic",
+        "builder"
+    ],
+    "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
+    "readmeFilename": "README.md",
+    "homepage": "https://github.com/concon121/java-generator-plus/#readme",
+    "_id": "java-generator@2.1.0",
+    "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
+    "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
+    "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
+    "_atomModuleCache": {
+        "version": 1,
+        "dependencies": [],
+        "extensions": {
+            ".coffee": [
+                "lib\\command.coffee",
+                "lib\\java-generator.coffee",
+                "lib\\parser.coffee",
+                "lib\\variable.coffee"
+            ],
+            ".json": [
+                "package.json"
+            ]
+        },
+        "folders": []
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,66 +1,66 @@
 {
-  "name": "java-generator",
-  "main": "./lib/java-generator",
-  "version": "2.5.0",
-  "private": true,
-  "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
-  "repository": "https://github.com/concon121/java-generator-plus",
-  "bugs": {
-    "url": "https://github.com/concon121/java-generator-plus/issues"
-  },
-  "license": "Apache 2.0",
-  "author": {
-    "name": "Tom Delebo",
-    "url": "https://github.com/delebota"
-  },
-  "engines": {
-    "atom": ">=1.0.0 <2.0.0"
-  },
-  "dependencies": {},
-  "activationCommands": {
-    "atom-workspace": [
-      "java-generator:generate-constructor",
-      "java-generator:generate-to-string",
-      "java-generator:generate-builder",
-      "java-generator:generate-getters-setters"
-    ]
-  },
-  "keywords": [
-    "atom",
-    "java",
-    "get",
-    "getter",
-    "set",
-    "setter",
-    "constructor",
-    "toString",
-    "generate",
-    "format",
-    "auto",
-    "automatic",
-    "builder"
-  ],
-  "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
-  "readmeFilename": "README.md",
-  "homepage": "https://github.com/concon121/java-generator-plus/#readme",
-  "_id": "java-generator@2.1.0",
-  "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
-  "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
-  "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
-  "_atomModuleCache": {
-    "version": 1,
-    "dependencies": [],
-    "extensions": {
-      ".coffee": [
-        "lib\\command.coffee",
-        "lib\\java-generator.coffee",
-        "lib\\parser.coffee",
-        "lib\\variable.coffee"
-      ],
-      ".json": [
-        "package.json"
-      ]
+    "name": "java-generator-plus",
+    "main": "./lib/java-generator",
+    "version": "2.5.0",
+    "private": true,
+    "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
+    "repository": "https://github.com/concon121/java-generator-plus",
+    "bugs": {
+        "url": "https://github.com/concon121/java-generator-plus/issues"
     },
-    "folders": []
-  }
+    "license": "Apache 2.0",
+    "author": {
+        "name": "Tom Delebo",
+        "url": "https://github.com/delebota"
+    },
+    "engines": {
+        "atom": ">=1.0.0 <2.0.0"
+    },
+    "dependencies": {},
+    "activationCommands": {
+        "atom-workspace": [
+            "java-generator:generate-constructor",
+            "java-generator:generate-to-string",
+            "java-generator:generate-builder",
+            "java-generator:generate-getters-setters"
+        ]
+    },
+    "keywords": [
+        "atom",
+        "java",
+        "get",
+        "getter",
+        "set",
+        "setter",
+        "constructor",
+        "toString",
+        "generate",
+        "format",
+        "auto",
+        "automatic",
+        "builder"
+    ],
+    "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
+    "readmeFilename": "README.md",
+    "homepage": "https://github.com/concon121/java-generator-plus/#readme",
+    "_id": "java-generator@2.1.0",
+    "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
+    "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
+    "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
+    "_atomModuleCache": {
+        "version": 1,
+        "dependencies": [],
+        "extensions": {
+            ".coffee": [
+                "lib\\command.coffee",
+                "lib\\java-generator.coffee",
+                "lib\\parser.coffee",
+                "lib\\variable.coffee"
+            ],
+            ".json": [
+                "package.json"
+            ]
+        },
+        "folders": []
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "java-generator",
   "main": "./lib/java-generator",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "private": true,
   "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
   "repository": "https://github.com/concon121/java-generator-plus",

--- a/package.json
+++ b/package.json
@@ -1,66 +1,66 @@
 {
-    "name": "java-generator-plus",
-    "main": "./lib/java-generator",
-    "version": "2.5.0",
-    "private": true,
-    "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
-    "repository": "https://github.com/concon121/java-generator-plus",
-    "bugs": {
-        "url": "https://github.com/concon121/java-generator-plus/issues"
+  "name": "java-generator-plus",
+  "main": "./lib/java-generator",
+  "version": "2.6.0",
+  "private": true,
+  "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
+  "repository": "https://github.com/concon121/java-generator-plus",
+  "bugs": {
+    "url": "https://github.com/concon121/java-generator-plus/issues"
+  },
+  "license": "Apache 2.0",
+  "author": {
+    "name": "Tom Delebo",
+    "url": "https://github.com/delebota"
+  },
+  "engines": {
+    "atom": ">=1.0.0 <2.0.0"
+  },
+  "dependencies": {},
+  "activationCommands": {
+    "atom-workspace": [
+      "java-generator:generate-constructor",
+      "java-generator:generate-to-string",
+      "java-generator:generate-builder",
+      "java-generator:generate-getters-setters"
+    ]
+  },
+  "keywords": [
+    "atom",
+    "java",
+    "get",
+    "getter",
+    "set",
+    "setter",
+    "constructor",
+    "toString",
+    "generate",
+    "format",
+    "auto",
+    "automatic",
+    "builder"
+  ],
+  "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/concon121/java-generator-plus/#readme",
+  "_id": "java-generator@2.1.0",
+  "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
+  "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
+  "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
+  "_atomModuleCache": {
+    "version": 1,
+    "dependencies": [],
+    "extensions": {
+      ".coffee": [
+        "lib\\command.coffee",
+        "lib\\java-generator.coffee",
+        "lib\\parser.coffee",
+        "lib\\variable.coffee"
+      ],
+      ".json": [
+        "package.json"
+      ]
     },
-    "license": "Apache 2.0",
-    "author": {
-        "name": "Tom Delebo",
-        "url": "https://github.com/delebota"
-    },
-    "engines": {
-        "atom": ">=1.0.0 <2.0.0"
-    },
-    "dependencies": {},
-    "activationCommands": {
-        "atom-workspace": [
-            "java-generator:generate-constructor",
-            "java-generator:generate-to-string",
-            "java-generator:generate-builder",
-            "java-generator:generate-getters-setters"
-        ]
-    },
-    "keywords": [
-        "atom",
-        "java",
-        "get",
-        "getter",
-        "set",
-        "setter",
-        "constructor",
-        "toString",
-        "generate",
-        "format",
-        "auto",
-        "automatic",
-        "builder"
-    ],
-    "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
-    "readmeFilename": "README.md",
-    "homepage": "https://github.com/concon121/java-generator-plus/#readme",
-    "_id": "java-generator@2.1.0",
-    "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
-    "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
-    "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
-    "_atomModuleCache": {
-        "version": 1,
-        "dependencies": [],
-        "extensions": {
-            ".coffee": [
-                "lib\\command.coffee",
-                "lib\\java-generator.coffee",
-                "lib\\parser.coffee",
-                "lib\\variable.coffee"
-            ],
-            ".json": [
-                "package.json"
-            ]
-        },
-        "folders": []
-    }
+    "folders": []
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,69 +1,69 @@
 {
-  "name": "java-generator",
-  "main": "./lib/java-generator",
-  "version": "2.1.1",
-  "private": true,
-  "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/delebota/java-generator.git"
-  },
-  "bugs": {
-    "url": "https://github.com/delebota/java-generator/issues"
-  },
-  "license": "Apache 2.0",
-  "author": {
-    "name": "Tom Delebo",
-    "url": "https://github.com/delebota"
-  },
-  "engines": {
-    "atom": ">=1.0.0 <2.0.0"
-  },
-  "dependencies": {},
-  "activationCommands": {
-    "atom-workspace": [
-      "java-generator:generate-constructor",
-      "java-generator:generate-to-string",
-      "java-generator:generate-builder",
-      "java-generator:generate-getters-setters"
-    ]
-  },
-  "keywords": [
-    "atom",
-    "java",
-    "get",
-    "getter",
-    "set",
-    "setter",
-    "constructor",
-    "toString",
-    "generate",
-    "format",
-    "auto",
-    "automatic",
-    "builder"
-  ],
-  "readme": "# Java Generator\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n",
-  "readmeFilename": "README.md",
-  "homepage": "https://github.com/delebota/java-generator#readme",
-  "_id": "java-generator@2.1.0",
-  "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
-  "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
-  "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
-  "_atomModuleCache": {
-    "version": 1,
-    "dependencies": [],
-    "extensions": {
-      ".coffee": [
-        "lib\\command.coffee",
-        "lib\\java-generator.coffee",
-        "lib\\parser.coffee",
-        "lib\\variable.coffee"
-      ],
-      ".json": [
-        "package.json"
-      ]
+    "name": "java-generator",
+    "main": "./lib/java-generator",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/concon121/java-generator-plus"
     },
-    "folders": []
-  }
+    "bugs": {
+        "url": "https://github.com/concon121/java-generator-plus/issues"
+    },
+    "license": "Apache 2.0",
+    "author": {
+        "name": "Tom Delebo",
+        "url": "https://github.com/delebota"
+    },
+    "engines": {
+        "atom": ">=1.0.0 <2.0.0"
+    },
+    "dependencies": {},
+    "activationCommands": {
+        "atom-workspace": [
+            "java-generator:generate-constructor",
+            "java-generator:generate-to-string",
+            "java-generator:generate-builder",
+            "java-generator:generate-getters-setters"
+        ]
+    },
+    "keywords": [
+        "atom",
+        "java",
+        "get",
+        "getter",
+        "set",
+        "setter",
+        "constructor",
+        "toString",
+        "generate",
+        "format",
+        "auto",
+        "automatic",
+        "builder"
+    ],
+    "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
+    "readmeFilename": "README.md",
+    "homepage": "https://github.com/concon121/java-generator-plus/#readme",
+    "_id": "java-generator@2.1.0",
+    "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
+    "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
+    "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
+    "_atomModuleCache": {
+        "version": 1,
+        "dependencies": [],
+        "extensions": {
+            ".coffee": [
+                "lib\\command.coffee",
+                "lib\\java-generator.coffee",
+                "lib\\parser.coffee",
+                "lib\\variable.coffee"
+            ],
+            ".json": [
+                "package.json"
+            ]
+        },
+        "folders": []
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,69 +1,69 @@
 {
-  "name": "java-generator",
-  "main": "./lib/java-generator",
-  "version": "0.1.0",
-  "private": true,
-  "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/concon121/java-generator-plus"
-  },
-  "bugs": {
-    "url": "https://github.com/concon121/java-generator-plus/issues"
-  },
-  "license": "Apache 2.0",
-  "author": {
-    "name": "Tom Delebo",
-    "url": "https://github.com/delebota"
-  },
-  "engines": {
-    "atom": ">=1.0.0 <2.0.0"
-  },
-  "dependencies": {},
-  "activationCommands": {
-    "atom-workspace": [
-      "java-generator:generate-constructor",
-      "java-generator:generate-to-string",
-      "java-generator:generate-builder",
-      "java-generator:generate-getters-setters"
-    ]
-  },
-  "keywords": [
-    "atom",
-    "java",
-    "get",
-    "getter",
-    "set",
-    "setter",
-    "constructor",
-    "toString",
-    "generate",
-    "format",
-    "auto",
-    "automatic",
-    "builder"
-  ],
-  "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
-  "readmeFilename": "README.md",
-  "homepage": "https://github.com/concon121/java-generator-plus/#readme",
-  "_id": "java-generator@2.1.0",
-  "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
-  "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
-  "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
-  "_atomModuleCache": {
-    "version": 1,
-    "dependencies": [],
-    "extensions": {
-      ".coffee": [
-        "lib\\command.coffee",
-        "lib\\java-generator.coffee",
-        "lib\\parser.coffee",
-        "lib\\variable.coffee"
-      ],
-      ".json": [
-        "package.json"
-      ]
+    "name": "java-generator",
+    "main": "./lib/java-generator",
+    "version": "2.1.1",
+    "private": true,
+    "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/concon121/java-generator-plus"
     },
-    "folders": []
-  }
+    "bugs": {
+        "url": "https://github.com/concon121/java-generator-plus/issues"
+    },
+    "license": "Apache 2.0",
+    "author": {
+        "name": "Tom Delebo",
+        "url": "https://github.com/delebota"
+    },
+    "engines": {
+        "atom": ">=1.0.0 <2.0.0"
+    },
+    "dependencies": {},
+    "activationCommands": {
+        "atom-workspace": [
+            "java-generator:generate-constructor",
+            "java-generator:generate-to-string",
+            "java-generator:generate-builder",
+            "java-generator:generate-getters-setters"
+        ]
+    },
+    "keywords": [
+        "atom",
+        "java",
+        "get",
+        "getter",
+        "set",
+        "setter",
+        "constructor",
+        "toString",
+        "generate",
+        "format",
+        "auto",
+        "automatic",
+        "builder"
+    ],
+    "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
+    "readmeFilename": "README.md",
+    "homepage": "https://github.com/concon121/java-generator-plus/#readme",
+    "_id": "java-generator@2.1.0",
+    "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
+    "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
+    "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
+    "_atomModuleCache": {
+        "version": 1,
+        "dependencies": [],
+        "extensions": {
+            ".coffee": [
+                "lib\\command.coffee",
+                "lib\\java-generator.coffee",
+                "lib\\parser.coffee",
+                "lib\\variable.coffee"
+            ],
+            ".json": [
+                "package.json"
+            ]
+        },
+        "folders": []
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,66 +1,66 @@
 {
-    "name": "java-generator",
-    "main": "./lib/java-generator",
-    "version": "2.3.0",
-    "private": true,
-    "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
-    "repository": "https://github.com/concon121/java-generator-plus",
-    "bugs": {
-        "url": "https://github.com/concon121/java-generator-plus/issues"
+  "name": "java-generator",
+  "main": "./lib/java-generator",
+  "version": "2.4.0",
+  "private": true,
+  "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
+  "repository": "https://github.com/concon121/java-generator-plus",
+  "bugs": {
+    "url": "https://github.com/concon121/java-generator-plus/issues"
+  },
+  "license": "Apache 2.0",
+  "author": {
+    "name": "Tom Delebo",
+    "url": "https://github.com/delebota"
+  },
+  "engines": {
+    "atom": ">=1.0.0 <2.0.0"
+  },
+  "dependencies": {},
+  "activationCommands": {
+    "atom-workspace": [
+      "java-generator:generate-constructor",
+      "java-generator:generate-to-string",
+      "java-generator:generate-builder",
+      "java-generator:generate-getters-setters"
+    ]
+  },
+  "keywords": [
+    "atom",
+    "java",
+    "get",
+    "getter",
+    "set",
+    "setter",
+    "constructor",
+    "toString",
+    "generate",
+    "format",
+    "auto",
+    "automatic",
+    "builder"
+  ],
+  "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/concon121/java-generator-plus/#readme",
+  "_id": "java-generator@2.1.0",
+  "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
+  "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
+  "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
+  "_atomModuleCache": {
+    "version": 1,
+    "dependencies": [],
+    "extensions": {
+      ".coffee": [
+        "lib\\command.coffee",
+        "lib\\java-generator.coffee",
+        "lib\\parser.coffee",
+        "lib\\variable.coffee"
+      ],
+      ".json": [
+        "package.json"
+      ]
     },
-    "license": "Apache 2.0",
-    "author": {
-        "name": "Tom Delebo",
-        "url": "https://github.com/delebota"
-    },
-    "engines": {
-        "atom": ">=1.0.0 <2.0.0"
-    },
-    "dependencies": {},
-    "activationCommands": {
-        "atom-workspace": [
-            "java-generator:generate-constructor",
-            "java-generator:generate-to-string",
-            "java-generator:generate-builder",
-            "java-generator:generate-getters-setters"
-        ]
-    },
-    "keywords": [
-        "atom",
-        "java",
-        "get",
-        "getter",
-        "set",
-        "setter",
-        "constructor",
-        "toString",
-        "generate",
-        "format",
-        "auto",
-        "automatic",
-        "builder"
-    ],
-    "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
-    "readmeFilename": "README.md",
-    "homepage": "https://github.com/concon121/java-generator-plus/#readme",
-    "_id": "java-generator@2.1.0",
-    "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
-    "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
-    "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
-    "_atomModuleCache": {
-        "version": 1,
-        "dependencies": [],
-        "extensions": {
-            ".coffee": [
-                "lib\\command.coffee",
-                "lib\\java-generator.coffee",
-                "lib\\parser.coffee",
-                "lib\\variable.coffee"
-            ],
-            ".json": [
-                "package.json"
-            ]
-        },
-        "folders": []
-    }
+    "folders": []
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,69 +1,69 @@
 {
-    "name": "java-generator",
-    "main": "./lib/java-generator",
-    "version": "2.1.1",
-    "private": true,
-    "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/concon121/java-generator-plus"
+  "name": "java-generator",
+  "main": "./lib/java-generator",
+  "version": "2.2.0",
+  "private": true,
+  "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/concon121/java-generator-plus"
+  },
+  "bugs": {
+    "url": "https://github.com/concon121/java-generator-plus/issues"
+  },
+  "license": "Apache 2.0",
+  "author": {
+    "name": "Tom Delebo",
+    "url": "https://github.com/delebota"
+  },
+  "engines": {
+    "atom": ">=1.0.0 <2.0.0"
+  },
+  "dependencies": {},
+  "activationCommands": {
+    "atom-workspace": [
+      "java-generator:generate-constructor",
+      "java-generator:generate-to-string",
+      "java-generator:generate-builder",
+      "java-generator:generate-getters-setters"
+    ]
+  },
+  "keywords": [
+    "atom",
+    "java",
+    "get",
+    "getter",
+    "set",
+    "setter",
+    "constructor",
+    "toString",
+    "generate",
+    "format",
+    "auto",
+    "automatic",
+    "builder"
+  ],
+  "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/concon121/java-generator-plus/#readme",
+  "_id": "java-generator@2.1.0",
+  "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
+  "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
+  "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
+  "_atomModuleCache": {
+    "version": 1,
+    "dependencies": [],
+    "extensions": {
+      ".coffee": [
+        "lib\\command.coffee",
+        "lib\\java-generator.coffee",
+        "lib\\parser.coffee",
+        "lib\\variable.coffee"
+      ],
+      ".json": [
+        "package.json"
+      ]
     },
-    "bugs": {
-        "url": "https://github.com/concon121/java-generator-plus/issues"
-    },
-    "license": "Apache 2.0",
-    "author": {
-        "name": "Tom Delebo",
-        "url": "https://github.com/delebota"
-    },
-    "engines": {
-        "atom": ">=1.0.0 <2.0.0"
-    },
-    "dependencies": {},
-    "activationCommands": {
-        "atom-workspace": [
-            "java-generator:generate-constructor",
-            "java-generator:generate-to-string",
-            "java-generator:generate-builder",
-            "java-generator:generate-getters-setters"
-        ]
-    },
-    "keywords": [
-        "atom",
-        "java",
-        "get",
-        "getter",
-        "set",
-        "setter",
-        "constructor",
-        "toString",
-        "generate",
-        "format",
-        "auto",
-        "automatic",
-        "builder"
-    ],
-    "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
-    "readmeFilename": "README.md",
-    "homepage": "https://github.com/concon121/java-generator-plus/#readme",
-    "_id": "java-generator@2.1.0",
-    "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
-    "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
-    "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
-    "_atomModuleCache": {
-        "version": 1,
-        "dependencies": [],
-        "extensions": {
-            ".coffee": [
-                "lib\\command.coffee",
-                "lib\\java-generator.coffee",
-                "lib\\parser.coffee",
-                "lib\\variable.coffee"
-            ],
-            ".json": [
-                "package.json"
-            ]
-        },
-        "folders": []
-    }
+    "folders": []
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,69 +1,69 @@
 {
-    "name": "java-generator",
-    "main": "./lib/java-generator",
-    "version": "0.0.0",
-    "private": true,
-    "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/concon121/java-generator-plus"
+  "name": "java-generator",
+  "main": "./lib/java-generator",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/concon121/java-generator-plus"
+  },
+  "bugs": {
+    "url": "https://github.com/concon121/java-generator-plus/issues"
+  },
+  "license": "Apache 2.0",
+  "author": {
+    "name": "Tom Delebo",
+    "url": "https://github.com/delebota"
+  },
+  "engines": {
+    "atom": ">=1.0.0 <2.0.0"
+  },
+  "dependencies": {},
+  "activationCommands": {
+    "atom-workspace": [
+      "java-generator:generate-constructor",
+      "java-generator:generate-to-string",
+      "java-generator:generate-builder",
+      "java-generator:generate-getters-setters"
+    ]
+  },
+  "keywords": [
+    "atom",
+    "java",
+    "get",
+    "getter",
+    "set",
+    "setter",
+    "constructor",
+    "toString",
+    "generate",
+    "format",
+    "auto",
+    "automatic",
+    "builder"
+  ],
+  "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/concon121/java-generator-plus/#readme",
+  "_id": "java-generator@2.1.0",
+  "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
+  "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
+  "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
+  "_atomModuleCache": {
+    "version": 1,
+    "dependencies": [],
+    "extensions": {
+      ".coffee": [
+        "lib\\command.coffee",
+        "lib\\java-generator.coffee",
+        "lib\\parser.coffee",
+        "lib\\variable.coffee"
+      ],
+      ".json": [
+        "package.json"
+      ]
     },
-    "bugs": {
-        "url": "https://github.com/concon121/java-generator-plus/issues"
-    },
-    "license": "Apache 2.0",
-    "author": {
-        "name": "Tom Delebo",
-        "url": "https://github.com/delebota"
-    },
-    "engines": {
-        "atom": ">=1.0.0 <2.0.0"
-    },
-    "dependencies": {},
-    "activationCommands": {
-        "atom-workspace": [
-            "java-generator:generate-constructor",
-            "java-generator:generate-to-string",
-            "java-generator:generate-builder",
-            "java-generator:generate-getters-setters"
-        ]
-    },
-    "keywords": [
-        "atom",
-        "java",
-        "get",
-        "getter",
-        "set",
-        "setter",
-        "constructor",
-        "toString",
-        "generate",
-        "format",
-        "auto",
-        "automatic",
-        "builder"
-    ],
-    "readme": "# Java Generator Plus\n\nAn Atom.io package created to generate getter, setter, toString, constructor, and builder methods for java classes.\n\n## Keyboard Shortcuts\n\n```text\nctrl-alt-g: Generate Getters and Setters\nctrl-alt-c: Generate Constructor\nctrl-alt-t: Generate toString Method\nctrl-alt-b: Generate Builder Method\n```\n\nThis project is a fork of the original java-generator, which you can find [here](https://github.com/delebota/java-generator)",
-    "readmeFilename": "README.md",
-    "homepage": "https://github.com/concon121/java-generator-plus/#readme",
-    "_id": "java-generator@2.1.0",
-    "_shasum": "20b7a8674e9e618753d8956b9c2831e6473793e2",
-    "_resolved": "file:..\\d-1151030-8396-1w3pkmq\\package.tgz",
-    "_from": "..\\d-1151030-8396-1w3pkmq\\package.tgz",
-    "_atomModuleCache": {
-        "version": 1,
-        "dependencies": [],
-        "extensions": {
-            ".coffee": [
-                "lib\\command.coffee",
-                "lib\\java-generator.coffee",
-                "lib\\parser.coffee",
-                "lib\\variable.coffee"
-            ],
-            ".json": [
-                "package.json"
-            ]
-        },
-        "folders": []
-    }
+    "folders": []
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "java-generator",
   "main": "./lib/java-generator",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "description": "Generates getter, setter, toString, constructor, and builder methods for java classes.",
   "repository": {


### PR DESCRIPTION
Fix for the [issue](https://github.com/delebota/java-generator/issues/11) that I raised.  This change adds support for generic type parameters, so that getters and setters are generated correctly. Example generated output below:

    public class Test {

        private static final String NON_CHANGEY_STRING = "yolo";
        private String stringyString;
        private Map<String, List<String>> mappyList;
        private List<String> listyString;

	    /**
	    * Returns value of NON_CHANGEY_STRING
	    * @return
	    */
	    public static String getNON_CHANGEY_STRING() {
	    	    return NON_CHANGEY_STRING;
	    }

	    /**
	    * Returns value of stringyString
	    * @return
	    */
	    public String getStringyString() {
		    return stringyString;
	    }

	    /**
	    * Sets new value of stringyString
	    * @param
	    */
	    public void setStringyString(String stringyString) {
		    this.stringyString = stringyString;
	    }

	    /**
	    * Returns value of mappyList
	    * @return
	    */
	    public Map<String, List<String>> getMappyList() {
		    return mappyList;
	    }

	    /**
	    * Sets new value of mappyList
	    * @param
	    */
	    public void setMappyList(Map<String, List<String>> mappyList) {
		    this.mappyList = mappyList;
	    }

	    /**
	    * Returns value of listyString
	    * @return
	    */
	    public List<String> getListyString() {
		    return listyString;
	    }

	    /**
	    * Sets new value of listyString
	    * @param
	    */
	    public void setListyString(List<String> listyString) {
		    this.listyString = listyString;
	    }
      }